### PR TITLE
Cross Origin check utility and implementation

### DIFF
--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -9,7 +9,7 @@ import React, {
 import { useOpenCv } from 'opencv-react'
 import T from 'prop-types'
 
-import { calcDims, readFile, isCrossOriginURL } from './utils'
+import { calcDims, readFile, isCrossOriginURL } from '../lib/utils'
 import CropPoints from '../lib/CropPoints'
 import { applyFilter, transform } from '../lib/imgManipulation'
 import CropPointsDelimiters from './CropPointsDelimiters'

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -9,7 +9,7 @@ import React, {
 import { useOpenCv } from 'opencv-react'
 import T from 'prop-types'
 
-import { calcDims, readFile } from '../lib/utils'
+import { calcDims, readFile, isCrossOriginURL } from "./utils";
 import CropPoints from '../lib/CropPoints'
 import { applyFilter, transform } from '../lib/imgManipulation'
 import CropPointsDelimiters from './CropPointsDelimiters'
@@ -108,6 +108,7 @@ const Canvas = ({
         setPreviewPaneDimensions()
         resolve()
       }
+      if (isCrossOriginURL(src)) img.crossOrigin = true;
       img.src = src
     })
   }

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -108,7 +108,7 @@ const Canvas = ({
         setPreviewPaneDimensions()
         resolve()
       }
-      if (isCrossOriginURL(src)) img.crossOrigin = true
+      if (isCrossOriginURL(src)) img.crossOrigin = "anonymous"
       img.src = src
     })
   }

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -9,7 +9,7 @@ import React, {
 import { useOpenCv } from 'opencv-react'
 import T from 'prop-types'
 
-import { calcDims, readFile, isCrossOriginURL } from "./utils";
+import { calcDims, readFile, isCrossOriginURL } from './utils'
 import CropPoints from '../lib/CropPoints'
 import { applyFilter, transform } from '../lib/imgManipulation'
 import CropPointsDelimiters from './CropPointsDelimiters'
@@ -108,7 +108,7 @@ const Canvas = ({
         setPreviewPaneDimensions()
         resolve()
       }
-      if (isCrossOriginURL(src)) img.crossOrigin = true;
+      if (isCrossOriginURL(src)) img.crossOrigin = true
       img.src = src
     })
   }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -38,3 +38,15 @@ export const calcDims = (
   }
   return calculated
 }
+
+export function isCrossOriginURL(url) {
+  const { location } = window;
+  const parts = url.match(/^(\w+:)\/\/([^:/?#]*):?(\d*)/i);
+
+  return (
+    parts !== null &&
+    (parts[1] !== location.protocol ||
+      parts[2] !== location.hostname ||
+      parts[3] !== location.port)
+  );
+}


### PR DESCRIPTION
Added a utility that is able to check for cross origin using regex. 

Sets crossOrigin on image to true if it is a cross origin resource.

(fixes a cross-origin "this action is unsafe" error when using images from other websites or api's)