### PR TITLE
Feature/opt in filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ export interface CropperProps {
 export interface filterCvParams = {
   blur: boolean,
   th: boolean,
-  thMode: integer, //provided by OpenCV
-  thMeanCorrection: integer,
-  thBlockSize: integer,
-  thMax: integer,
-  grayScale: false,
+  thMode: number, //provided by OpenCV
+  thMeanCorrection: number,
+  thBlockSize: number,
+  thMax: number,
+  grayScale: boolean,
 }
 ```
 ## Usage

--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ export interface CropperProps {
   openCvPath: string
 }
 ```
-
+## OpenCV Filter Props
+```typescript
+export interface filterCvParams = {
+  blur: boolean,
+  th: boolean,
+  thMode: integer, //provided by OpenCV
+  thMeanCorrection: integer,
+  thBlockSize: integer,
+  thMax: integer,
+  grayScale: false,
+}
+```
 ## Usage
 
 ```jsx
@@ -101,6 +112,73 @@ const App = () => {
   )
 }
 ```
+
+## Applying Filters Example
+
+```jsx
+import React from 'react'
+import Cropper from 'react-perspective-cropper'
+
+const App = () => {
+  const [cropState, setCropState] = useState()
+  const [img, setImg] = useState()
+  const [inputKey, setInputKey] = useState(0)
+  const cropperRef = useRef()
+
+  const onDragStop = useCallback((s) => setCropState(s), [])
+  const onChange = useCallback((s) => setCropState(s), [])
+
+  const doSomething = async () => {
+    console.log(cropState)
+    try {
+      // Get the OpenCV ref
+      const { cv } = cropperRef.current;
+      // Declare the filter params that should be applied to the cropped image
+      const filter = { 
+        blur: false,
+        th: true,
+        thMode: cv.ADAPTIVE_THRESH_MEAN_C,
+        thMeanCorrection: 15,
+        thBlockSize: 25,
+        thMax: 255,
+        grayScale: true,
+      };
+      
+      const res = await cropperRef.current.done({ 
+        preview: true,
+        filterCvParams: filter
+      })
+      console.log(res)
+    } catch (e) {
+      console.log('error', e)
+    }
+  }
+
+  const onImgSelection = async (e) => {
+    if (e.target.files && e.target.files.length > 0) {
+      // it can also be a http or base64 string for example
+      setImg(e.target.files[0])
+    }
+  }
+
+  return (
+    <Cropper
+      ref={cropperRef}
+      image={img}
+      onChange={onChange}
+      onDragStop={onDragStop}
+    />
+    <input
+      type='file'
+      key={inputKey}
+      onChange={onImgSelection}
+      accept='image/*'
+    />
+    <button onClick={doSomething}>Ho finito</button>
+  )
+}
+```
+
 
 ## OpenCV
 

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -58,7 +58,11 @@ const Canvas = ({
           imageResizeRatio,
           setPreviewPaneDimensions
         )
-        applyFilter(cv, canvasRef.current, opts.filterCvParams)
+        
+        if(opts.filterCvParams){
+          applyFilter(cv, canvasRef.current, opts.filterCvParams)
+        }
+        
         if (opts.preview) {
           setMode('preview')
         }

--- a/src/lib/Canvas.js
+++ b/src/lib/Canvas.js
@@ -72,7 +72,8 @@ const Canvas = ({
           setLoading(false)
         }, image.type)
       })
-    }
+    },
+    cv
   }))
 
   useEffect(() => {

--- a/src/lib/imgManipulation.js
+++ b/src/lib/imgManipulation.js
@@ -61,12 +61,12 @@ export const applyFilter = async (cv, docCanvas, filterCvParams) => {
   // default options
   const options = {
     blur: false,
-    th: true,
+    th: false,
     thMode: cv.ADAPTIVE_THRESH_MEAN_C,
     thMeanCorrection: 15,
     thBlockSize: 25,
     thMax: 255,
-    grayScale: true,
+    grayScale: false,
     ...filterCvParams
   }
   const dst = cv.imread(docCanvas)


### PR DESCRIPTION
As mentioned in #13 
**Feature:  opt-in ApplyFilter**
The filters are now only applied if a filterCvParams object is provided to the "done" function.
to maintain readability of the code the ref to the loaded opencv lib is exposed to the cropperRef and can be used to declare certain values of the filterCvParams object.
In addition default filter properties have been set to false.

And the Readme file has been updated with a set of values that can be used for a filter object and an example of the previously default filter applied with the new opt-in structure.